### PR TITLE
Broken if condition in validate_pr workflow

### DIFF
--- a/.github/workflows/validate-PR.yml
+++ b/.github/workflows/validate-PR.yml
@@ -11,7 +11,7 @@ jobs:
           AUTO_MERGE: ${{ secrets.AUTO_MERGE }}
         steps:
           - name: Check if active
-            if: env.AUTO_MERGE != '1'
+            if: ${{ env.AUTO_MERGE != '1' }}
             run: exit 1 
           - name: Get code
             uses: actions/checkout@v4


### PR DESCRIPTION
The PR fixes a broken if condition in the validate_pr workflow so that `AUTO_MERGE` is properly checked before running the action