### PR TITLE
Shift validate PR to on pull_request_target

### DIFF
--- a/.github/workflows/validate-PR.yml
+++ b/.github/workflows/validate-PR.yml
@@ -2,7 +2,7 @@
 
 name: Validate PR
 on:
-    pull_request:
+    pull_request_target:
 
 jobs: 
     validate-PR:


### PR DESCRIPTION
This PR shifts the workflow `validate-PR` from `pull-request` to `pull_request_target` in order to access the base repo's secrets and successfully perform the `AUTO_MERGE` check